### PR TITLE
spanner make error code settable

### DIFF
--- a/spanner/errors.go
+++ b/spanner/errors.go
@@ -242,3 +242,9 @@ func (e *Error) ErrCode() codes.Code {
 	}
 	return e.Code
 }
+
+// Errorf generates a *spanner.Error with the given description and a
+// status error with the given error code as its wrapped error.
+func Errorf(code codes.Code, format string, args ...interface{}) error {
+	return spannerErrorf(code, format, args...)
+}


### PR DESCRIPTION
TL;DR: after 9f47821ebd7e01e6ff3fa65f57dcd8afe59e2e57 `spanner.ErrCode(&spanner.Error{Code: codes.NotFound}) == codes.Unknown`. We need a means of being able to instantiate coded spanner errors for unit tests outside of this package.